### PR TITLE
Reorder product categories on detail page

### DIFF
--- a/src/app/api/cloudflare/products/route.ts
+++ b/src/app/api/cloudflare/products/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest) {
         p.id, p.name, p.description, p.price, p.prices, 
         p.image_url, p.video_url, p.stock, p.is_available,
         c.name as category,
+        c.icon as category_icon,
         p.category_id, p.features, p.tags
       FROM products p
       LEFT JOIN categories c ON p.category_id = c.id
@@ -58,6 +59,7 @@ export async function GET(request: NextRequest) {
           name: product.name,
           description: product.description || '',
           category: product.category || 'Sans catégorie',
+          category_icon: product.category_icon || '🏷️',
           category_id: product.category_id,
           image_url: product.image_url || '',
           video_url: product.video_url || '',

--- a/src/app/api/products-simple/route.ts
+++ b/src/app/api/products-simple/route.ts
@@ -21,6 +21,7 @@ export async function GET() {
             p.id, p.name, p.description, p.price, p.prices, 
             p.image_url, p.video_url, p.stock, p.is_available,
             c.name as category_name,
+            c.icon as category_icon,
             p.category_id, p.features, p.tags
           FROM products p
           LEFT JOIN categories c ON p.category_id = c.id
@@ -56,6 +57,7 @@ export async function GET() {
           name: product.name,
           description: product.description || '',
           category: product.category_name || 'Sans catégorie',
+          category_icon: product.category_icon || '🏷️',
           category_id: product.category_id,
           image_url: product.image_url || '',
           video_url: product.video_url || '',

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -4,6 +4,7 @@ interface Product {
   id: number;
   name: string;
   category: string;
+  category_icon?: string;
   image_url: string;
   video_url?: string;
   description?: string;
@@ -44,7 +45,7 @@ export default function ProductCard({ product, onClick }: ProductCardProps) {
         
         {/* Badge catégorie - responsive */}
         <div className="absolute top-2 left-2 bg-white text-black text-xxs sm:text-xs font-bold px-1.5 sm:px-2 py-0.5 sm:py-1 rounded-md shadow-lg max-w-[80%] truncate">
-          {product.category}
+          {product.category_icon ? `${product.category} ${product.category_icon}` : product.category}
         </div>
         
         {/* Indicateur vidéo - responsive */}

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -123,7 +123,14 @@ export default function ProductDetail({ product, onClose }: ProductDetailProps) 
               <h2 className="text-xl sm:text-2xl font-bold text-white uppercase tracking-wide">
                 {product.name}
               </h2>
-              <p className="text-gray-400 font-medium mt-1">{product.category}</p>
+              <p className="text-gray-400 font-medium mt-1">
+                {product.category_icon && (
+                  <>
+                    {product.category} {product.category_icon}
+                  </>
+                )}
+                {!product.category_icon && product.category}
+              </p>
               <p className="text-gray-400 uppercase tracking-widest text-xs sm:text-sm" />
             </div>
             


### PR DESCRIPTION
Fetch and display category icons after the category name on product detail and card pages.

This change ensures categories are displayed in the format `Category Name Icon` (e.g., "Edible 🧁") instead of just the category name, and that icons are consistently shown where available.

---
<a href="https://cursor.com/background-agent?bcId=bc-a988994f-e0fd-460b-b04c-abc62086e149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a988994f-e0fd-460b-b04c-abc62086e149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

